### PR TITLE
Prepare 5.2.25

### DIFF
--- a/bdii.spec
+++ b/bdii.spec
@@ -1,5 +1,5 @@
 Name:		bdii
-Version:	5.2.24
+Version:	5.2.25
 Release:	1%{?dist}
 Summary:	The Berkeley Database Information Index (BDII)
 
@@ -121,6 +121,10 @@ fi
 %doc /usr/share/doc/bdii/LICENSE.txt
 
 %changelog
+
+* Tue Oct 2 2018 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.25-1
+- Import product card JSON in codemeta.json format (Bruce Becker)
+- Lint, build, test install and attach packages to GitHub tags using Travis. (Baptiste Grenier)
 
 * Mon Aug 27 2018 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.24-1
 - Fix #3: init script failing on stale PID (Paolo Andreetto)

--- a/codemeta.json
+++ b/codemeta.json
@@ -31,7 +31,7 @@
     "centos 6",
     "centos 7"
   ],
-  "installUrl": "https://malandes.web.cern.ch/malandes/infosys/rpms/emi-bdii-site-1.0.2-1.el7.cern.noarch.rpm",
+  "installUrl": "https://github.com/EGI-Foundation/glite-info-update-endpoints/releases",
   "buildInstructions": "http://gridinfo-documentation.readthedocs.io/",
   "releaseNotes": "",
   "codeRepository": "https://github.com/EGI-Foundation/bdii",


### PR DESCRIPTION
Prepare for 5.2.25 release.
Use a generic installUrl allowing to grab the different artefacts.