### PR TITLE
Prepare 5.5.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ script:
   - docker exec -i -w /src/build/RPMS/noarch install_container sh -c "yum localinstall -y bdii*.el${OS_MAJOR_VERSION}.noarch.rpm"
 deploy:
   provider: releases
-  api_key:
-    secure: tw560GrnanaDUSQ27wmyn+tryv7NYwvKjafc23VWpJRw78BYrIZopAL3r/YN9k7iQmk0WyJ7pjV3ayL/XSW0vYhCme1hpKaKTrRl8r+C4pJcmz9q50bVE1G2invgiqiw2Tpne7BG/LS7aERQxPs2tgmzvoy0XLFgoWOec+cBts5D+KtAnOZ5jxob6V9K1na79pK9OK4mVt/rYeuqEb8O44tjHywa7PWzg9mHAtzAGLtrgki3ICEosFkqRyBaQmwbLc/fUhA1De9TtGtbxaQ3GYRCIgnQTJ5DNOcuj3X21WlXGhQXEovR1oC3lBwMPxx2Ap1Ke3JNIU9y8YiW7CGqQm8XV9wm5PFN6O2ZccjPRVp+xkGkl0w1+RL/Ms2zfevFaxztqzKCt+AVXDw4aQrxyawuNCRLku3uzzQa0cQPfJscWHAqLCTXSP13hbKyyu+nvVFBpMjY6xO8TICHeb5dXVOU1JIw6Qu+AqfEIYZQsNuJI6SUwkkonHrRZ0iEfLi+0JQ8adelGqCfDiK7bDSFQ4prjLECjjp3HHSrvvcRNl8gEc+0P/qdWsIdC8j1a332f3VsO3JF/8+NWjU2Uy8fs04DyzWM4l3Ccg+7DEfx/zdPWCwlzNq6giByMiDm0RvPgrNVigdN8o6QnVOxkpeL4lNnOVfIb/RtJq4ND3zKvOE=
+  # Set in the settings page of the repository, as an environment variable
+  api_key: $GITHUB_TOKEN
   file_glob: true
   file:
     - build/RPMS/noarch/bdii*.el${OS_MAJOR_VERSION}.noarch.rpm

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Paolo Andreetto <paolo.andreetto@pd.infn.it>
 Petr Vokac https://github.com/vokac
 Andrea Manzi <andrea.manzi@egi.eu>
 Mattias Ellert <mattias.ellert@physics.uu.se>
+Enol Fernández <enol.fernandez@egi.eu>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,5 @@
 Maintainers
 -----------
-Paolo Andreetto <paolo.andreetto@pd.infn.it>
 Baptiste Grenier <baptiste.grenier@egi.eu>
 
 Original Authors
@@ -15,3 +14,7 @@ Maarten Litmaath <Maarten.Litmaath@cern.ch>
 Felix Ehm <Felix.Ehm@cern.ch>
 Andrew Elwell <Andrew.Elwell@cern.ch>
 Daniel Johansson <daniel@ndgf.org>
+Paolo Andreetto <paolo.andreetto@pd.infn.it>
+Petr Vokac https://github.com/vokac
+Andrea Manzi <andrea.manzi@egi.eu>
+Mattias Ellert <mattias.ellert@physics.uu.se>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Whenever a remote server is contacted and the ldapsearch command times out
 the update process tries to find an (old) cached entry in the `/var/cache/`
 directory. If no entry is found a message is printed to the logfile.
 
-*Attention!*
+_Attention!_
 If the remote host cannot be contacted due to a connection problem
 no cached entry is taken. No message is printed to the logfile.
 
@@ -58,8 +58,8 @@ The description of thoese metrics can be found in the etc/BDII.schema file.
 make install
 ```
 
-* Build dependencies: None
-* Runtime dependencies: openldap
+- Build dependencies: None
+- Runtime dependencies: openldap
 
 ## Building packages
 
@@ -67,9 +67,9 @@ make install
 
 The required build dependencies are:
 
-* rpm-build
-* make
-* rsync
+- rpm-build
+- make
+- rsync
 
 ```sh
 # Checkout tag to be packaged
@@ -99,6 +99,17 @@ cd /source && make deb
 ```
 
 The DEB will be available into the `build/` directory.
+
+## Preparing a release
+
+- Prepare a changelog from the last version, including contributors' names
+- Prepare a PR with
+  - Updating version and changelog in `bdii.spec`
+  - Updating version and changelog in `debian/changelog`
+  - Updating authors in `AUTHORS`
+  - Updating `codemeta.json` if needed
+- Once the PR has been merged tag and release a new version in GitHub
+  - Packages will be built using Travis and attached to the release page
 
 ## History
 

--- a/bdii.spec
+++ b/bdii.spec
@@ -123,8 +123,8 @@ fi
 %changelog
 
 * Wed Sep 23 2020 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.26-1
-- Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
-- Preserve base64 entries (Petr Vokac)
+- Truncate LDIF password file before updating (Petr Vokac)
+- Preserve base64 entries (Enol Fernández, Andrea Manzi)
 - Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
 
 * Tue Oct 2 2018 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.25-1

--- a/bdii.spec
+++ b/bdii.spec
@@ -1,5 +1,5 @@
 Name:		bdii
-Version:	5.2.25
+Version:	5.2.26
 Release:	1%{?dist}
 Summary:	The Berkeley Database Information Index (BDII)
 
@@ -121,6 +121,11 @@ fi
 %doc /usr/share/doc/bdii/LICENSE.txt
 
 %changelog
+
+* Wed Sep 23 2020 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.26-1
+- Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
+- Preserver base64 entries (Petr Vokac)
+- Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
 
 * Tue Oct 2 2018 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.25-1
 - Import product card JSON in codemeta.json format (Bruce Becker)

--- a/bdii.spec
+++ b/bdii.spec
@@ -124,7 +124,7 @@ fi
 
 * Wed Sep 23 2020 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.26-1
 - Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
-- Preserver base64 entries (Petr Vokac)
+- Preserve base64 entries (Petr Vokac)
 - Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
 
 * Tue Oct 2 2018 Baptiste Grenier <baptiste.grenier@egi.eu> - 5.2.25-1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+bdii (5.2.26-1) UNRELEASED; urgency=low
+
+  * Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
+  * Preserver base64 entries (Petr Vokac)
+  * Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu> Wed, 23 Sep 2020 11:02:00 +0100
+
 bdii (5.2.24-1) UNRELEASED; urgency=low
 
   * Fix #3: init script failing on stale PID (Paolo Andreetto)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 bdii (5.2.26-1) UNRELEASED; urgency=low
 
-  * Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
-  * Preserve base64 entries (Petr Vokac)
+  * Truncate LDIF password file before updating (Petr Vokac)
+  * Preserve base64 entries (Enol Fernández, Andrea Manzi)
   * Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
 
  -- Baptiste Grenier <baptiste.grenier@egi.eu> Wed, 23 Sep 2020 11:02:00 +0100

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 bdii (5.2.26-1) UNRELEASED; urgency=low
 
   * Truncate LDIF password file before updating (Enol Fernández, Andrea Manzi)
-  * Preserver base64 entries (Petr Vokac)
+  * Preserve base64 entries (Petr Vokac)
   * Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)
 
  -- Baptiste Grenier <baptiste.grenier@egi.eu> Wed, 23 Sep 2020 11:02:00 +0100


### PR DESCRIPTION
Prepare 5.5.26.

Changelog:
- Truncate LDIF password file before updating (Petr Vokac)
- Preserve base64 entries (Enol Fernández, Andrea Manzi)
- Allow BDII_HOSTNAME configuration and default to localhost (Andrea Manzi)