### PR TITLE
Prepare new release 6.0.1.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [6.0.1] - 2023-03-28
+
+### Changed
+
+- Build and release using AlmaLinux 8 and 9. (#45) (Baptiste Grenier)
+- Align Makefile with other repositories. (#45) (Baptiste Grenier)
+- Allow long yaml files for GitHub Actions (#45) (Baptiste Grenier)
+
 ## [6.0.0]
+
 - Drop debian-specific files and reference official packages (#44) (Baptiste Grenier)
 - Migrate to MDB backend for OpenLDAP 2.5 on recent OS (#42) (Mattias Ellert)
 - Fix runtime errors while iterating dictionary in python 3 (#39) (Andrea Manzi)
@@ -16,6 +25,7 @@ and this project adheres to
 - Quality control using GitHub actions, update community files (#26) (Baptiste Grenier)
 
 ## [5.2.26]
+
 - Truncate LDIF password file before updating (#14) (Petr Vokac)
 - Preserve base64 entries (#21) (Enol Fernández, Andrea Manzi)
 - Allow BDII_HOSTNAME configuration and default to localhost (#22) (Andrea Manzi)

--- a/bdii.spec
+++ b/bdii.spec
@@ -11,7 +11,7 @@
 %endif
 
 Name: bdii
-Version: 6.0.0
+Version: 6.0.1
 Release: 1%{?dist}
 Summary: The Berkeley Database Information Index (BDII)
 
@@ -152,6 +152,11 @@ fi
 %license COPYRIGHT LICENSE.txt
 
 %changelog
+
+* Tue Mar 28 2023 Baptiste Grenier <baptiste.grenier@egi.eu> - 6.0.1-1
+- Build and release using AlmaLinux 8 and 9. (#45) (Baptiste Grenier)
+- Align Makefile with other repositories. (#45) (Baptiste Grenier)
+- Allow long yaml files for GitHub Actions (#45) (Baptiste Grenier)
 
 * Thu Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 6.0.0-1
 - Migrate to MDB backend for OpenLDAP 2.5 on recent OS (#42) (Mattias Ellert)


### PR DESCRIPTION
Prepare new release 6.0.1.

```markdown
## [6.0.1] - 2023-03-28

### Changed

- Build and release using AlmaLinux 8 and 9. (#45) (Baptiste Grenier)
- Align Makefile with other repositories. (#45) (Baptiste Grenier)
- Allow long yaml files for GitHub Actions (#45) (Baptiste Grenier)
```