### PR TITLE
Update bdii-slapd-start for IPv6 support

### DIFF
--- a/etc/systemd/bdii-slapd-start
+++ b/etc/systemd/bdii-slapd-start
@@ -18,7 +18,7 @@ DELAYED_DELETE=${DELAYED_DELETE:-${BDII_VAR_DIR}/delayed_delete.pkl}
 BDII_RAM_SIZE=${BDII_RAM_SIZE:-1500M}
 
 if [ "${BDII_IPV6_SUPPORT}" == "yes" ]; then
-    SLAPD_HOST_STRING="'ldap://${SLAPD_HOST}:${SLAPD_PORT} ldap://[${SLAPD_HOST6}]:${SLAPD_PORT}'"
+    SLAPD_HOST_STRING="ldap://${SLAPD_HOST}:${SLAPD_PORT} ldap://[${SLAPD_HOST6}]:${SLAPD_PORT}"
 else
     SLAPD_HOST_STRING="ldap://${SLAPD_HOST}:${SLAPD_PORT}"
 fi
@@ -75,6 +75,5 @@ else
     fi
 fi
 
-COMMAND="${SLAPD} -f ${SLAPD_CONF} -h ${SLAPD_HOST_STRING} -u ${BDII_USER}"
-exec ${COMMAND}
-
+COMMAND="${SLAPD} -f ${SLAPD_CONF} -h \"${SLAPD_HOST_STRING}\" -u ${BDII_USER}"
+exec sh -c "${COMMAND}"


### PR DESCRIPTION
# Summary

I would like to propose an alternative solution to #50. I find this solution less confusing since it does not use bash arrays.

**Related issue :** #50