### PR TITLE
fix: updated log.warn to log.warning

### DIFF
--- a/bin/bdii-update
+++ b/bin/bdii-update
@@ -543,13 +543,13 @@ def log_errors(error_file, dns):
                     if not dn == dns[request - 2]:
                         error_counter += 1
                         dn = dns[request - 2]
-                        log.warn("dn: %s" % dn)
+                        log.warning("dn: %s" % dn)
                 except IndexError:
                     log.error("Problem with error reporting ...")
                     log.error("Request Num: %i, Line: %s, dns: %i" %
                               (request, line, len(dns)))
             if len(line) > 5:
-                log.warn(line.strip())
+                log.warning(line.strip())
     return error_counter
 
 


### PR DESCRIPTION
# Summary

Replaces log.warn with the python standard log.warning

---

**Related issue :**

fixes #53