### PR TITLE
Start using -H instead of deprecated -h and -p. Fixes #49

### DIFF
--- a/bin/bdii-update
+++ b/bin/bdii-update
@@ -271,7 +271,7 @@ def read_ldif(source):
         # Open pipe to LDIF
         if source[:7] == 'ldap://':
             url = source.split('/')
-            command = "ldapsearch -LLL -x -H %s -b %s 2>/dev/null" % (
+            command = "ldapsearch -LLL -x -H ldap://%s -b %s 2>/dev/null" % (
                       url[2], url[3])
             pipe = os.popen(command)
         elif source[:7] == 'file://':

--- a/bin/bdii-update
+++ b/bin/bdii-update
@@ -271,9 +271,7 @@ def read_ldif(source):
         # Open pipe to LDIF
         if source[:7] == 'ldap://':
             url = source.split('/')
-            # TODO: use -H
-            # FIXME: where is my port?
-            command = "ldapsearch -LLL -x -h %s -b %s 2>/dev/null" % (
+            command = "ldapsearch -LLL -x -H %s -b %s 2>/dev/null" % (
                       url[2], url[3])
             pipe = os.popen(command)
         elif source[:7] == 'file://':

--- a/bin/bdii-update
+++ b/bin/bdii-update
@@ -271,6 +271,8 @@ def read_ldif(source):
         # Open pipe to LDIF
         if source[:7] == 'ldap://':
             url = source.split('/')
+            # TODO: use -H
+            # FIXME: where is my port?
             command = "ldapsearch -LLL -x -h %s -b %s 2>/dev/null" % (
                       url[2], url[3])
             pipe = os.popen(command)
@@ -701,7 +703,7 @@ def main(config, log):
                 if "o=shadow" in config['BDII_PASSWD']:
                     if root == "o=grid":
                         bind = "o=shadow"
-                input_fh = os.popen(("ldapadd -d 256 -x -c -h %s -p %s"
+                input_fh = os.popen(("ldapadd -d 256 -x -c -H ldap://%s:%s"
                                      " -D %s -y %s >/dev/null 2>%s") % (
                                          config['BDII_HOSTNAME'],
                                          config['BDII_PORT'],
@@ -741,7 +743,7 @@ def main(config, log):
                 if "o=shadow" in config['BDII_PASSWD']:
                     if root == "o=grid":
                         bind = "o=shadow"
-                input_fh = os.popen(("ldapmodify -d 256 -x -c -h %s -p %s -D"
+                input_fh = os.popen(("ldapmodify -d 256 -x -c -H ldap://%s:%s -D"
                                      " %s -y %s >/dev/null 2>%s") % (
                                          config['BDII_HOSTNAME'],
                                          config['BDII_PORT'],
@@ -841,7 +843,7 @@ def main(config, log):
                 if "o=shadow" in config['BDII_PASSWD']:
                     if root == "o=grid":
                         bind = "o=shadow"
-                input_fh = os.popen(("ldapdelete -d 256 -x -c -h %s -p %s"
+                input_fh = os.popen(("ldapdelete -d 256 -x -c -H ldap://%s:%s"
                                      " -D %s -y %s >/dev/null 2>%s") % (
                                          config['BDII_HOSTNAME'],
                                          config['BDII_PORT'],
@@ -869,7 +871,7 @@ def main(config, log):
         for root in roots.keys():
             # Stop flapping due to o=shadow
             if root == "o=shadow":
-                command = ("ldapsearch -LLL -x -h %s -p %s -b %s -s base"
+                command = ("ldapsearch -LLL -x -H ldap://%s:%s -b %s -s base"
                            " >> %s/old.ldif 2>> %s/old.err") % (
                                    config['BDII_HOSTNAME'],
                                    config['BDII_PORT'],
@@ -877,7 +879,7 @@ def main(config, log):
                                    config['BDII_VAR_DIR'],
                                    config['BDII_VAR_DIR'])
             else:
-                command = ("ldapsearch -LLL -x -h %s -p %s -b %s"
+                command = ("ldapsearch -LLL -x -H ldap://%s:%s -b %s"
                            " >> %s/old.ldif 2>> %s/old.err") % (
                                    config['BDII_HOSTNAME'],
                                    config['BDII_PORT'],
@@ -917,7 +919,7 @@ def main(config, log):
             infosys_output += "replace: Data\n"
             infosys_output += "Data: file://%s\n\n" % out_file
         try:
-            output_fh = os.popen(("%s -x -c -h %s -p %s -D o=infosys -y %s"
+            output_fh = os.popen(("%s -x -c -H ldap://%s:%s -D o=infosys -y %s"
                                   " >/dev/null") % (
                                       command,
                                       config['BDII_HOSTNAME'],
@@ -989,7 +991,7 @@ def main(config, log):
                     infosys_output += "-\n"
             infosys_output += "\n"
         try:
-            output_fh = os.popen(("%s -x -c -h %s -p %s -D o=infosys -y %s"
+            output_fh = os.popen(("%s -x -c -h ldap://%s:%s -D o=infosys -y %s"
                                   " >/dev/null") % (
                                       command,
                                       config['BDII_HOSTNAME'],

--- a/bin/bdii-update
+++ b/bin/bdii-update
@@ -989,7 +989,7 @@ def main(config, log):
                     infosys_output += "-\n"
             infosys_output += "\n"
         try:
-            output_fh = os.popen(("%s -x -c -h ldap://%s:%s -D o=infosys -y %s"
+            output_fh = os.popen(("%s -x -c -H ldap://%s:%s -D o=infosys -y %s"
                                   " >/dev/null") % (
                                       command,
                                       config['BDII_HOSTNAME'],


### PR DESCRIPTION
Start using -H instead of deprecated `-h` and `-p` parameters on OpenLDAP 2.5, see https://openldap.org/doc/admin25/appendix-upgrading.html.

The `-H` parameter should be present since long, cf https://www.openldap.org/software/man.cgi?query=ldapadd&apropos=0&sektion=1&manpath=OpenLDAP+2.2-Release&arch=default&format=html.

Fix #49.

