### PR TITLE
Prepare 6.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [6.0.2] - 2024-06-14
+
+### Changed
+
+- Fix for IPv6 support. (#51) (Mattias Ellert)
+- Replace obsolete -h and -p paremeters in ldap CLI tools. (#49) (Baptiste Grenier)
+- Fix deprecation warning due to log.warn. (#58) (Daniela Bauer)
+
 ## [6.0.1] - 2023-03-28
 
 ### Changed

--- a/bdii.spec
+++ b/bdii.spec
@@ -11,7 +11,7 @@
 %endif
 
 Name: bdii
-Version: 6.0.1
+Version: 6.0.2
 Release: 1%{?dist}
 Summary: The Berkeley Database Information Index (BDII)
 
@@ -152,6 +152,11 @@ fi
 %license COPYRIGHT LICENSE.txt
 
 %changelog
+
+* Fri Jun 14 2024 Baptiste Grenier <baptiste.grenier@egi.eu> - 6.0.2-1
+- Fix for IPv6 support. (#51) (Mattias Ellert)
+- Replace obsolete -h and -p paremeters in ldap CLI tools. (#49) (Baptiste Grenier)
+- Fix deprecation warning due to log.warn. (#58) (Daniela Bauer)
 
 * Tue Mar 28 2023 Baptiste Grenier <baptiste.grenier@egi.eu> - 6.0.1-1
 - Build and release using AlmaLinux 8 and 9. (#45) (Baptiste Grenier)


### PR DESCRIPTION
# [6.0.2] - 2024-06-14

# Changed

- Fix for IPv6 support. (#51) (Mattias Ellert)
- Replace obsolete -h and -p paremeters in ldap CLI tools. (#49) (Baptiste Grenier)
- Fix deprecation warning due to log.warn. (#58) (Daniela Bauer)