### PR TITLE
actions/checkout v4 do not work on RHEL 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/centos/centos:7
     steps:
-      - uses: actions/checkout@v4
+      # XXX: Checkout v4 do not work on RHEL 7
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: install build requisites


### PR DESCRIPTION
actions/checkout v4 do not work on RHEL 7.
See https://github.com/EGI-Federation/bdii/actions/runs/9543330578/job/26299738320

At some point we will drop support for packaging and releasing for CentOS 7, but it wasn't yet decided.